### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ For details, please check out Flyway [documentation].
 
 [flyway]: https://flywaydb.org/
 [documentation]: https://flywaydb.org/documentation/configuration/parameters/
+
+## Version matrix
+
+| Action version | Flyway version running      |
+|----------------|-----------------------------|
+| @v3.0.0        | flyway community edition v9 |
+| @v2.1.0        | flyway community edition v8 |
+| @v2            | flyway community edition v7 |
+| @v1            | flyway community edition v7 |
+
+## Note
+
+### Database compatibility
+
+> Flyway Community Edition `8.0.0-beta1` dropped support for databases older than 5 years, including MySQL `5.7`.  
+> The minimum supported version of MySQL was increased from `5.7` to `8.0`.
+
+For details, please check out Flyway [release note](https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html#8.0.0-beta1).

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ For details, please check out Flyway [documentation].
 ### Database compatibility
 
 > Flyway Community Edition `8.0.0-beta1` dropped support for databases older than 5 years, including MySQL `5.7`.  
-> The minimum supported version of MySQL was increased from `5.7` to `8.0`.
+> The minimum supported version of MySQL was increased from `5.7` to `8.0` in [this commit](https://github.com/flyway/flyway/commit/4622cee057c855a718533d60aecb2c3e21960a5f#diff-bba65157fbd0a2962cf37cd0e4625186c2dc6508d4433bb6f0a03a5b564d4815).
 
 For details, please check out Flyway [release note](https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html#8.0.0-beta1).


### PR DESCRIPTION
## What type of PR is this?

Update docs

## Background

During the process of using this action, I wasted time due to MySQL 5.7 compatibility issues.
Need to mention version compatibility, which is a breaking change starting from flyway community edition v8.

## What this PR does

- Add version matrix to compare `flyway-action` version and the flyway community edition version
- Add note for MySQL 5.7 database compatibility

## Additional documentation

This PR is closely related to the external links below.

- [Flyway release notes](https://documentation.red-gate.com/fd/release-notes-for-flyway-engine-179732572.html#8.0.0-beta1)
- [Stack overflow question](https://stackoverflow.com/questions/70438180/what-is-the-last-version-of-flyway-community-edition-that-supported-mysql-5-7)
- [flyway/flway commit](https://github.com/flyway/flyway/commit/4622cee057c855a718533d60aecb2c3e21960a5f#diff-bba65157fbd0a2962cf37cd0e4625186c2dc6508d4433bb6f0a03a5b564d4815)